### PR TITLE
BloomFilter

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -5,35 +5,48 @@ import (
     "encoding/binary"
 )
 
-type HashID uint64
+type FTaskID uint64
 
-func Hash(b []byte) HashID {
+type BFHash [4]uint64
+
+func Hash(b []byte) FTaskID {
     sum := md5.Sum(b)
-    return HashID(binary.BigEndian.Uint64([]byte(sum[:])))
+    return FTaskID(binary.BigEndian.Uint64([]byte(sum[:])))
 }
 
-type Seed struct {
-    NodeId      int
+// baseHashes returns the four hash values of data that are used to create k
+// hashes
+func BloomHash(data []byte) BFHash {
+	var d Digest128 // murmur hashing
+	hash1, hash2, hash3, hash4 := d.Sum256(data)
+	return [4]uint64{
+		hash1, hash2, hash3, hash4,
+	}
+}
+
+type SeedInfo struct {
+    NodeId      uint64
+    Id          FTaskID
     Bytes       []byte
-    CovHash     HashID
-    CovEdges    int
+    CovHash     BFHash
+    CovEdges    uint64
     Crash       bool
 }
 
 type Stats struct {
-    Its           int
+    Its           uint64
     Port          int
-    Havoc         int
-    CrashN        int
-    SeedsN        int
-    MaxSeed       Seed
+    Havoc         uint64
+    CrashN        uint64
+    SeedsN        uint64
+    MaxCov        uint64
     UniqueCrashes int
-    UniquePaths   int
+    UniquePaths   uint64
     Nodes         int
 }
 
 type FTask struct {
-    Id       HashID
+    Id       FTaskID
     Seed     []byte
     Die      bool
 }
@@ -42,20 +55,15 @@ type FTaskArgs struct {
 
 }
 
-type Coverage struct {
-    NodeId   int
-    Type     string
-}
-
 type UpdateReply struct {
     Log      bool
 }
 
 type UpdateFTask struct {
-    NodeId   int
+    NodeId   uint64
     Ok       bool
-    Id       HashID
-    CovHash  HashID
-    CovEdges int
+    Id       FTaskID
+    CovHash  BFHash
+    CovEdges uint64
     Crash    string
 }

--- a/common/murmur.go
+++ b/common/murmur.go
@@ -1,0 +1,289 @@
+/*
+Hopper uses the implementation from the following bloom Library for mumur hash:
+https://github.com/bits-and-blooms/bloom. We require this because the default
+implementation of bloomfilter interface doesn't fit the exact requirments needed
+by Hopper. TLDR; the hash needs to sometimes be computed on worker nodes.
+
+
+The bloom library relied on the excellent murmur library
+by Sébastien Paolacci. Unfortunately, it involved some heap
+allocation. We want to avoid any heap allocation whatsoever
+in the hashing process. To preserve backward compatibility, we roll
+our own hashing functions. They are designed to be strictly equivalent
+to Paolacci's implementation.
+
+License on original code:
+
+Copyright 2013, Sébastien Paolacci.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the library nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package common
+
+import (
+	"math/bits"
+	"unsafe"
+)
+
+const (
+	c1_128     = 0x87c37b91114253d5
+	c2_128     = 0x4cf5ad432745937f
+	block_size = 16
+)
+
+// digest128 represents a partial evaluation of a 128 bites hash.
+type Digest128 struct {
+	h1 uint64 // Unfinalized running hash part 1.
+	h2 uint64 // Unfinalized running hash part 2.
+}
+
+//bmix will hash blocks (16 bytes)
+func (d *Digest128) bmix(p []byte) {
+	nblocks := len(p) / block_size
+	for i := 0; i < nblocks; i++ {
+		t := (*[2]uint64)(unsafe.Pointer(&p[i*block_size]))
+		k1, k2 := t[0], t[1]
+		d.bmix_words(k1, k2)
+	}
+}
+
+//bmix_words will hash two 64-bit words (16 bytes)
+func (d *Digest128) bmix_words(k1, k2 uint64) {
+	h1, h2 := d.h1, d.h2
+
+	k1 *= c1_128
+	k1 = bits.RotateLeft64(k1, 31)
+	k1 *= c2_128
+	h1 ^= k1
+
+	h1 = bits.RotateLeft64(h1, 27)
+	h1 += h2
+	h1 = h1*5 + 0x52dce729
+
+	k2 *= c2_128
+	k2 = bits.RotateLeft64(k2, 33)
+	k2 *= c1_128
+	h2 ^= k2
+
+	h2 = bits.RotateLeft64(h2, 31)
+	h2 += h1
+	h2 = h2*5 + 0x38495ab5
+	d.h1, d.h2 = h1, h2
+}
+
+// sum128 computers two 64-bit hash value. It is assumed that
+// bmix was first called on the data to process complete blocks
+// of 16 bytes. The 'tail' is a slice representing the 'tail' (leftover
+// elements, fewer than 16). If pad_tail is true, we make it seem like
+// there is an extra element with value 1 appended to the tail.
+// The length parameter represents the full length of the data (including
+// the blocks of 16 bytes, and, if pad_tail is true, an extra byte).
+func (d *Digest128) Sum128(pad_tail bool, length uint, tail []byte) (h1, h2 uint64) {
+	h1, h2 = d.h1, d.h2
+
+	var k1, k2 uint64
+	if pad_tail {
+		switch (len(tail) + 1) & 15 {
+		case 15:
+			k2 ^= uint64(1) << 48
+			break
+		case 14:
+			k2 ^= uint64(1) << 40
+			break
+		case 13:
+			k2 ^= uint64(1) << 32
+			break
+		case 12:
+			k2 ^= uint64(1) << 24
+			break
+		case 11:
+			k2 ^= uint64(1) << 16
+			break
+		case 10:
+			k2 ^= uint64(1) << 8
+			break
+		case 9:
+			k2 ^= uint64(1) << 0
+
+			k2 *= c2_128
+			k2 = bits.RotateLeft64(k2, 33)
+			k2 *= c1_128
+			h2 ^= k2
+
+			break
+
+		case 8:
+			k1 ^= uint64(1) << 56
+			break
+		case 7:
+			k1 ^= uint64(1) << 48
+			break
+		case 6:
+			k1 ^= uint64(1) << 40
+			break
+		case 5:
+			k1 ^= uint64(1) << 32
+			break
+		case 4:
+			k1 ^= uint64(1) << 24
+			break
+		case 3:
+			k1 ^= uint64(1) << 16
+			break
+		case 2:
+			k1 ^= uint64(1) << 8
+			break
+		case 1:
+			k1 ^= uint64(1) << 0
+			k1 *= c1_128
+			k1 = bits.RotateLeft64(k1, 31)
+			k1 *= c2_128
+			h1 ^= k1
+		}
+
+	}
+	switch len(tail) & 15 {
+	case 15:
+		k2 ^= uint64(tail[14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(tail[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(tail[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(tail[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(tail[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(tail[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(tail[8]) << 0
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		fallthrough
+
+	case 8:
+		k1 ^= uint64(tail[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(tail[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(tail[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(tail[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(tail[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(tail[0]) << 0
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(length)
+	h2 ^= uint64(length)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = fmix64(h1)
+	h2 = fmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	return h1, h2
+}
+
+func fmix64(k uint64) uint64 {
+	k ^= k >> 33
+	k *= 0xff51afd7ed558ccd
+	k ^= k >> 33
+	k *= 0xc4ceb9fe1a85ec53
+	k ^= k >> 33
+	return k
+}
+
+// sum256 will compute 4 64-bit hash values from the input.
+// It is designed to never allocate memory on the heap. So it
+// works without any byte buffer whatsoever.
+// It is designed to be strictly equivalent to
+// 			a1 := []byte{1}
+//          hasher := murmur3.New128()
+//          hasher.Write(data) // #nosec
+//          v1, v2 := hasher.Sum128()
+//          hasher.Write(a1) // #nosec
+//          v3, v4 := hasher.Sum128()
+// See TestHashRandom.
+func (d *Digest128) Sum256(data []byte) (hash1, hash2, hash3, hash4 uint64) {
+	// We always start from zero.
+	d.h1, d.h2 = 0, 0
+	// Process as many bytes as possible.
+	d.bmix(data)
+	// We have enough to compute the first two 64-bit numbers
+	length := uint(len(data))
+	tail_length := length % block_size
+	tail := data[length-tail_length:]
+	hash1, hash2 = d.Sum128(false, length, tail)
+	// Next we want to 'virtually' append 1 to the input, but,
+	// we do not want to append to an actual array!!!
+	if tail_length+1 == block_size {
+		// We are left with no tail!!!
+		word1 := *(*uint64)(unsafe.Pointer(&tail[0]))
+		word2 := uint64(*(*uint32)(unsafe.Pointer(&tail[8])))
+		word2 = word2 | (uint64(tail[12]) << 32) | (uint64(tail[13]) << 40) | (uint64(tail[14]) << 48)
+		// We append 1.
+		word2 = word2 | (uint64(1) << 56)
+		// We process the resulting 2 words.
+		d.bmix_words(word1, word2)
+		tail := data[length:] // empty slice, deliberate.
+		hash3, hash4 = d.Sum128(false, length+1, tail)
+	} else {
+		// We still have a tail (fewer than 15 bytes) but we
+		// need to append '1' to it.
+		hash3, hash4 = d.Sum128(true, length+1, tail)
+	}
+
+	return hash1, hash2, hash3, hash4
+}

--- a/compile
+++ b/compile
@@ -4,8 +4,8 @@
 #
 
 # clang-15
-CC="clang"
-CXX="clang++"
+CC="clang-15"
+CXX="clang++-15"
 
 # Symbols, ASAN, Edge Coverage
 CFLAGS=" -g -O0

--- a/compile
+++ b/compile
@@ -4,8 +4,8 @@
 #
 
 # clang-15
-CC="clang-15"
-CXX="clang++-15"
+CC="clang"
+CXX="clang++"
 
 # Symbols, ASAN, Edge Coverage
 CFLAGS=" -g -O0

--- a/examples/binutils/dist/master.sh
+++ b/examples/binutils/dist/master.sh
@@ -14,4 +14,4 @@ screen -S master -dm docker run -it --rm \
     --volume $LOCAL_OUT:$HOPPER_OUT \
     --publish 6969:6969 \
     hopper-readelf:latest \
-    bash -c "cd hopper; go build .; ./hopper -I ./examples/binutils/readelf/in -H=5"
+    bash -c "cd hopper; go build .; ./hopper -I ./examples/binutils/readelf/in -H=20"

--- a/examples/binutils/dist/node.sh
+++ b/examples/binutils/dist/node.sh
@@ -3,7 +3,7 @@
 ## Spawn Nodes
 export HOPPER_OUT="/hopper_out"
 LOCAL_OUT="/proj/hopper-tests-PG0/readelf-dat"
-MASTER_IP="amd171.utah.cloudlab.us"
+MASTER_IP="node0"
 PORT="6969"
 
 for ((i=$1;i<=$2;i++))

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/Cybergenik/hopper
 go 1.19
 
 require (
+	github.com/bits-and-blooms/bitset v1.5.0
 	github.com/charmbracelet/bubbletea v0.23.1
 	github.com/charmbracelet/lipgloss v0.6.0
-	github.com/tidwall/gjson v1.14.3
 )
 
 require (
@@ -20,8 +20,6 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.13.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52 v1.0.3 h1:DTwqENW7X9arYimJrPeGZcV0ln14sGMt3pHZspWD+Mg=
 github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
+github.com/bits-and-blooms/bitset v1.5.0 h1:NpE8frKRLGHIcEzkR+gZhiioW1+WbYV6fKwD6ZIpQT8=
+github.com/bits-and-blooms/bitset v1.5.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/charmbracelet/bubbletea v0.23.1 h1:CYdteX1wCiCzKNUlwm25ZHBIc1GXlYFyUIte8WPvhck=
 github.com/charmbracelet/bubbletea v0.23.1/go.mod h1:JAfGK/3/pPKHTnAS8JIE2u9f61BjWTQY57RbT25aMXU=
 github.com/charmbracelet/lipgloss v0.6.0 h1:1StyZB9vBSOyuZxQUcUwGr17JmojPNm87inij9N3wJY=
@@ -31,12 +33,6 @@ github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4Y
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
-github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func readCorpus(path string) [][]byte {
 func main() {
     help := flag.Bool("help", false, "help menu")
     input := flag.String("I", "", "path to input corpus, directory containing files each being a seed")
-    havoc := flag.Int("H", 1, "Havoc level to use in mutator, defaults to 1")
+    havoc := flag.Uint64("H", 1, "Havoc level to use in mutator, defaults to 1")
     port := flag.Int("P", 6969, "Port to use, defaults to :6969")
     //TODO: impl thread mode, shouldn't be too hard
     //thread_mode := flag.Bool("T", false, "Port to use, defaults to :6969")

--- a/master/bloomfilter.go
+++ b/master/bloomfilter.go
@@ -1,0 +1,138 @@
+/*
+Package bloom provides data structures and methods for creating Bloom filters.
+A Bloom filter is a representation of a set of _n_ items, where the main
+requirement is to make membership queries; _i.e._, whether an item is a
+member of a set.
+A Bloom filter has two parameters: _m_, a maximum size (typically a reasonably large
+multiple of the cardinality of the set to represent) and _k_, the number of hashing
+functions on elements of the set. (The actual hashing functions are important, too,
+but this is not a parameter for this implementation). A Bloom filter is backed by
+a BitSet; a key is represented in the filter by setting the bits at each value of the
+hashing functions (modulo _m_). Set membership is done by _testing_ whether the
+bits at each value of the hashing functions (again, modulo _m_) are set. If so,
+the item is in the set. If the item is actually in the set, a Bloom filter will
+never fail (the true positive rate is 1.0); but it is susceptible to false
+positives. The art is to choose _k_ and _m_ correctly.
+In this implementation, the hashing functions used is murmurhash,
+a non-cryptographic hashing function.
+This implementation accepts keys for setting as testing as []byte. Thus, to
+add a string item, "Love":
+    uint n = 1000
+    filter := bloom.New(20*n, 5) // load of 20, 5 keys
+    filter.Add([]byte("Love"))
+Similarly, to test if "Love" is in bloom:
+    if filter.Test([]byte("Love"))
+For numeric data, I recommend that you look into the binary/encoding library. But,
+for example, to add a uint32 to the filter:
+    i := uint32(100)
+    n1 := make([]byte,4)
+    binary.BigEndian.PutUint32(n1,i)
+    f.Add(n1)
+Finally, there is a method to estimate the false positive rate of a
+Bloom filter with _m_ bits and _k_ hashing functions for a set of size _n_:
+    if bloom.EstimateFalsePositiveRate(20*n, 5, n) > 0.001 ...
+You can use it to validate the computed m, k parameters:
+    m, k := bloom.EstimateParameters(n, fp)
+    ActualfpRate := bloom.EstimateFalsePositiveRate(m, k, n)
+or
+	f := bloom.NewWithEstimates(n, fp)
+	ActualfpRate := bloom.EstimateFalsePositiveRate(f.m, f.k, n)
+You would expect ActualfpRate to be close to the desired fp in these cases.
+The EstimateFalsePositiveRate function creates a temporary Bloom filter. It is
+also relatively expensive and only meant for validation.
+*/
+package master
+
+import (
+	"math"
+
+    c "github.com/Cybergenik/hopper/common"
+	"github.com/bits-and-blooms/bitset"
+)
+
+// A BloomFilter is a representation of a set of _n_ items, where the main
+// requirement is to make membership queries; _i.e._, whether an item is a
+// member of a set.
+
+type BloomFilter struct {
+	m uint
+	k uint
+	b *bitset.BitSet
+}
+
+func max(x, y uint) uint {
+	if x > y {
+		return x
+	}
+	return y
+}
+
+// New creates a new Bloom filter with _m_ bits and _k_ hashing functions
+// We force _m_ and _k_ to be at least one to avoid panics.
+func New(m uint, k uint) *BloomFilter {
+	return &BloomFilter{max(1, m), max(1, k), bitset.New(m)}
+}
+
+// location returns the ith hashed location using the four base hash values
+func location(h [4]uint64, i uint) uint64 {
+	ii := uint64(i)
+	return h[ii%2] + ii*h[2+(((ii+(ii%2))%4)/2)]
+}
+
+// location returns the ith hashed location using the four base hash values
+func (f *BloomFilter) location(h [4]uint64, i uint) uint {
+	return uint(location(h, i) % uint64(f.m))
+}
+
+// EstimateParameters estimates requirements for m and k.
+// Based on https://bitbucket.org/ww/bloom/src/829aa19d01d9/bloom.go
+// used with permission.
+func EstimateParameters(n uint, p float64) (m uint, k uint) {
+	m = uint(math.Ceil(-1 * float64(n) * math.Log(p) / math.Pow(math.Log(2), 2)))
+	k = uint(math.Ceil(math.Log(2) * float64(m) / float64(n)))
+	return
+}
+
+// NewWithEstimates creates a new Bloom filter for about n items with fp
+// false positive rate
+func NewWithEstimates(n uint, fp float64) *BloomFilter {
+	m, k := EstimateParameters(n, fp)
+	return New(m, k)
+}
+
+// Add data to the Bloom Filter. Returns the filter (allows chaining)
+func (f *BloomFilter) Add(data []byte) {
+	h := c.BloomHash(data)
+	for i := uint(0); i < f.k; i++ {
+		f.b.Set(f.location(h, i))
+	}
+}
+
+func (f *BloomFilter) AddHash(h c.BFHash) {
+	for i := uint(0); i < f.k; i++ {
+		f.b.Set(f.location(h, i))
+	}
+}
+
+// Contains returns true if the data is in the BloomFilter, false otherwise.
+// If true, the result might be a false positive. If false, the data
+// is definitely not in the set.
+func (f *BloomFilter) Contains(data []byte) bool {
+	h := c.BloomHash(data)
+	for i := uint(0); i < f.k; i++ {
+		if !f.b.Test(f.location(h, i)) {
+			return false
+		}
+	}
+	return true
+}
+
+
+func (f *BloomFilter) ContainsHash(h c.BFHash) bool {
+	for i := uint(0); i < f.k; i++ {
+		if !f.b.Test(f.location(h, i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/master/master.go
+++ b/master/master.go
@@ -81,7 +81,7 @@ func (h *Hopper) Report() {
     for cType, nodes := range h.crashes{
         crashes += cType + ": "
         for _, node := range nodes {
-            crashes += fmt.Sprintf("N %d ", node)
+            crashes += fmt.Sprintf("Node%d ", node)
         }
         crashes += "\n"
     }

--- a/master/master.go
+++ b/master/master.go
@@ -8,7 +8,6 @@ import (
     "path"
     "math"
     "sync"
-    "strconv"
     "net/rpc"
     "net/http"
 	"container/heap"
@@ -20,35 +19,39 @@ import (
 
 type Hopper struct {
     // Havoc level to use in mutator
-    havoc    int
+    havoc       uint64
     // seeds and Cov mutex
-    mu       sync.Mutex
+    mu          sync.Mutex
     // PQ mutex
-    pqMu     sync.Mutex
+    pqMu        sync.Mutex
     // Mutation function
-    mutf     func ([]byte, int) []byte
+    mutf        func ([]byte, uint64) []byte
     // PQ of seeds
-    pq       PriorityQueue
-    // seed map, used as set for deduping seeds and keeping track of Crashes
-    seeds    map[c.HashID]c.Seed
-    // cov map, used as set for deduping same coverage seeds
-    coverage  map[c.HashID]bool
+    pq          *PriorityQueue
+    // seed map, used as temporary rotating buffer while seeds are being fuzzed.
+    // Seeds exist ephemerally
+    seeds       map[c.FTaskID][]byte
+    // Seed BloomFilter, used as a set for deduping seeds
+    seedBF      *BloomFilter
+    // Coverage BloomFilter, used as set for deduping same coverage seeds
+    coverageBF  *BloomFilter
     // Coverage per number of nodes
-    crashes  map[string][]c.Seed
+    crashes     map[string][]uint64
     // Max Coverage in terms of edges
-    maxCov   c.Seed
+    maxCov      uint64
     // Port to host RPC
-    port     int
+    port        int
     // Queue Channel to add new seeds based on energy
-    qChan    chan c.HashID
+    qChan       chan c.FTaskID
     // Keeps track of whether Hopper has been killed
-    dead     int32
+    dead        int32
     // Node IDs
-    nodes    map[int]interface{}
+    nodes       map[uint64]bool
     //Stats
-    its      int
-    crashN   int
-    seedsN   int
+    its         uint64
+    crashN      uint64
+    seedsN      uint64
+    paths       uint64
 }
 
 const (
@@ -75,10 +78,10 @@ Nodes:          %v
 func (h *Hopper) Report() {
     h.mu.Lock()
     crashes := "Crashes:\n"
-    for cType, seeds := range h.crashes{
+    for cType, nodes := range h.crashes{
         crashes += cType + ": "
-        for _, s := range seeds {
-            crashes += "N"+strconv.Itoa(s.NodeId)+" "
+        for _, node := range nodes {
+            crashes += fmt.Sprintf("N %d ", node)
         }
         crashes += "\n"
     }
@@ -87,10 +90,10 @@ func (h *Hopper) Report() {
         h.havoc,
         h.seedsN,
         h.its,
-        h.maxCov.CovEdges,
+        h.maxCov,
         h.crashN,
         len(h.crashes),
-        len(h.coverage),
+        h.paths,
         len(h.nodes),
         crashes,
     )
@@ -118,9 +121,9 @@ func (h *Hopper) Stats() c.Stats{
         Havoc:         h.havoc,
         CrashN:        h.crashN,
         SeedsN:        h.seedsN,
-        MaxSeed:       h.maxCov,
+        MaxCov:        h.maxCov,
         UniqueCrashes: len(h.crashes),
-        UniquePaths:   len(h.coverage),
+        UniquePaths:   h.paths,
         Nodes:         len(h.nodes),
     }
 }
@@ -134,7 +137,7 @@ func (h *Hopper) GetFTask(args *c.FTaskArgs, task *c.FTask) error {
     seedHash := <-h.qChan 
     task.Id = seedHash
     h.mu.Lock()
-    task.Seed = h.seeds[seedHash].Bytes
+    task.Seed = h.seeds[seedHash]
     h.mu.Unlock()
     task.Die = h.killed()
     return nil
@@ -143,9 +146,9 @@ func (h *Hopper) GetFTask(args *c.FTaskArgs, task *c.FTask) error {
 func (h *Hopper) UpdateFTask(update *c.UpdateFTask, reply *c.UpdateReply) error {
     h.mu.Lock()
     defer h.mu.Unlock()
-    h.nodes[update.NodeId] = nil
-    // None unique or invalid seed
-    if _, ok := h.seeds[update.Id]; !ok && h.seeds[update.Id].NodeId != -1 {
+    h.nodes[update.NodeId] = true
+    // Check if seed in rotating Task buffer, has it already been processed
+    if _, ok := h.seeds[update.Id]; !ok {
         return nil
     }
     h.its++
@@ -154,35 +157,34 @@ func (h *Hopper) UpdateFTask(update *c.UpdateFTask, reply *c.UpdateReply) error 
         delete(h.seeds, update.Id)
         return nil
     }
-    h.seeds[update.Id] = c.Seed{
-        NodeId:   update.NodeId,
-        CovHash:  update.CovHash,
-        CovEdges: update.CovEdges,
-        Bytes:    h.seeds[update.Id].Bytes,
-        Crash:    update.Crash != "",
-    }
     // Dedup based on similar Coverage hash
-    if !h.coverage[update.CovHash]{
-        h.coverage[update.CovHash] = true
+    if !h.coverageBF.ContainsHash(update.CovHash){
+        h.coverageBF.AddHash(update.CovHash)
         // Found Unique crash, tell node to Log
         if (update.Crash != "") {
             reply.Log = true
-            h.crashes[update.Crash] = append(h.crashes[update.Crash], h.seeds[update.Id])
+            h.crashes[update.Crash] = append(h.crashes[update.Crash], update.NodeId)
         }
     }
-    s := h.seeds[update.Id]
-    go h.energyMutate(s, update.Id, h.maxCov.CovEdges)
-
-    //Free mutated seed
-    s.Bytes = nil
-    h.seeds[update.Id] = s
-
-    if update.CovEdges > h.maxCov.CovEdges{
-        h.maxCov = h.seeds[update.Id]
+    s := c.SeedInfo{
+        NodeId:   update.NodeId,
+        Id:       update.Id,
+        CovHash:  update.CovHash,
+        CovEdges: update.CovEdges,
+        Bytes:    h.seeds[update.Id],
+        Crash:    update.Crash != "",
     }
+    go h.energyMutate(s, h.maxCov)
+
     if (update.Crash != "") {
         h.crashN++
     }
+    if update.CovEdges > h.maxCov{
+        h.maxCov = s.CovEdges
+    }
+    //Free mutated seed
+    h.seeds[update.Id] = nil
+    delete(h.seeds, update.Id)
     return nil
 }
 
@@ -194,7 +196,7 @@ func (h *Hopper) mutGenerator() {
             baseline := float64(availableCap) * .01
             
             h.pqMu.Lock()
-            energyItem := heap.Pop(&h.pq).(*PQItem)
+            energyItem := heap.Pop(h.pq).(*PQItem)
             h.pqMu.Unlock()
             mutN := int(math.Max(1, energyItem.Energy * baseline))
             //fmt.Printf("baseline: %.2f * energy: %.2f = %d", baseline, energyItem.Energy, mutN)
@@ -207,17 +209,17 @@ func (h *Hopper) mutGenerator() {
     }
 }
 
-func (h *Hopper) energyMutate(seed c.Seed, seedHash c.HashID, maxEdges int) {
-    // Energy Range: [0, 1]
+func (h *Hopper) energyMutate(seed c.SeedInfo, maxEdges uint64) {
+    // Energy Range: (0, 1]
     energy := math.Min(1, float64(seed.CovEdges)/float64(maxEdges))
     if seed.Crash {
         energy += 1
     }
     h.pqMu.Lock()
     heap.Push(
-        &h.pq,
+        h.pq,
         &PQItem{
-            Id:       seedHash,
+            Id:       seed.Id,
             Seed:     seed.Bytes,
             Energy:   energy,
             priority: energy,
@@ -229,19 +231,14 @@ func (h *Hopper) energyMutate(seed c.Seed, seedHash c.HashID, maxEdges int) {
 // addSeed is by design blocking, we want to block the production of new seeds
 // until there is enough space in the Queue
 func (h *Hopper) addSeed(seed []byte) bool{
-    seedHash := c.Hash(seed)
-    h.mu.Lock()
-    if _, ok := h.seeds[seedHash]; ok {
-        h.mu.Unlock()
+    if h.seedBF.Contains(seed) {
         return false
     }
+    h.seedBF.Add(seed)
+    seedHash := c.Hash(seed)
+    h.mu.Lock()
     h.seedsN++
-    h.seeds[seedHash] = c.Seed{
-        NodeId:   -1,
-        Bytes:    seed,
-        CovHash:  0,
-        CovEdges: -1,
-    }
+    h.seeds[seedHash] = seed
     h.mu.Unlock()
     h.qChan <- seedHash
     return true
@@ -253,7 +250,7 @@ func (h *Hopper) rpcServer(){
     config := &net.ListenConfig{
         KeepAlive: 0,
     }
-    l, e := config.Listen(nil, "tcp", ":"+strconv.Itoa(h.port))
+    l, e := config.Listen(nil, "tcp", fmt.Sprintf(":%d", h.port))
     //l, e := net.Listen("tcp", ":"+strconv.Itoa(h.port))
     if e != nil {                              
         log.Fatal("listen error:", e)
@@ -261,30 +258,31 @@ func (h *Hopper) rpcServer(){
     go http.Serve(l, nil)                         
 }
 
-func InitHopper(havocN int, port int, mutf func([]byte, int) []byte, corpus [][]byte) *Hopper{
+func InitHopper(havocN uint64, port int, mutf func([]byte, uint64) []byte, corpus [][]byte) *Hopper{
     h := Hopper{
-        havoc:    havocN,
-        mutf:     mutf,
-        pq:       PriorityQueue{},
-        seeds:    make(map[c.HashID]c.Seed),
-        coverage: make(map[c.HashID]bool),
-        crashes:  make(map[string][]c.Seed),
-        maxCov:   c.Seed{},
-        port:     port,
-        nodes:    make(map[int]interface{}),
+        havoc:      havocN,
+        mutf:       mutf,
+        pq:         &PriorityQueue{},
+        seeds:      make(map[c.FTaskID][]byte),
+        seedBF:     NewWithEstimates(100_000_000, .001),
+        coverageBF: NewWithEstimates(100_000_000, .001),
+        crashes:    make(map[string][]uint64),
+        maxCov:     0,
+        port:       port,
+        nodes:      make(map[uint64]bool),
         //TODO: consider using circular buffer: container/ring
-        qChan:    make(chan c.HashID, 10000),
-        dead:     0,
-        its:      0,
-        crashN:   0,
-        seedsN:   0,
+        qChan:      make(chan c.FTaskID, 10000),
+        dead:       0,
+        its:        0,
+        crashN:     0,
+        seedsN:     0,
     }
 
     for _, seed := range corpus {
         h.addSeed(seed)
     }
     
-    heap.Init(&h.pq)
+    heap.Init(h.pq)
     // Spawn Energy Mutation Generator
     go h.mutGenerator()
 

--- a/master/mut.go
+++ b/master/mut.go
@@ -26,7 +26,7 @@ func main_(){
         os.Exit(1)
     }
     N := flag.Int("N", 1, "Number of mutations to produce")
-    H := flag.Int("H", 1, "Level of Havoc, number of individual mutation steps per mutation")
+    H := flag.Uint64("H", 1, "Level of Havoc, number of individual mutation steps per mutation")
     flag.Parse()
 
     bytes, err := os.ReadFile(flag.Arg(0))
@@ -39,13 +39,13 @@ func main_(){
     }
 }
 
-func Mutator(b []byte, havoc int) []byte {
+func Mutator(b []byte, havoc uint64) []byte {
     rand.Seed(time.Now().UnixNano())
     if len(b) == 0 {
         panic("Tried to mutate 0 bytes")
     }
     bytes := append([]byte{}, b...)
-    for i:=0; i<havoc;{
+    for i:=uint64(0); i<havoc;{
         switch rand.Intn(N){
         case MUT:
             i := rand.Intn(len(bytes))

--- a/master/pq.go
+++ b/master/pq.go
@@ -10,7 +10,7 @@ import (
 type PQItem struct {
     Seed     []byte
     Energy   float64
-    Id       c.HashID
+    Id       c.FTaskID
 	priority float64
 	index    int
 }

--- a/node/node.go
+++ b/node/node.go
@@ -11,23 +11,20 @@ import (
     "path/filepath"
     "net/rpc"
     "bytes"
-    "github.com/tidwall/gjson"
+
     c "github.com/Cybergenik/hopper/common"
 )
 
-//Deb sid: "sancov-15"
-const SANCOV = "sancov"
-
 type HopperNode struct {
-    loc         string
-    id          int
+    outDir      string
+    id          uint64
     target      string
     args        string
     env         []string
     stdin       bool
     raw         bool
     master      string
-    crashN      int
+    crashN      uint64
     conn        *rpc.Client
 }
 
@@ -51,51 +48,6 @@ func (n *HopperNode) updateFTask(ut c.UpdateFTask) bool {
     return reply.Log
 }
 
-func parseAsan(asan string) string{
-    asan_lines := strings.Split(asan, "\n")
-    for _, line := range asan_lines {
-        sline := strings.Split(line, " ")
-        if sline[0] == "SUMMARY:"{
-            return sline[2]
-        }
-    }
-    return ""
-}
-
-func (n *HopperNode) persistCrash(seed []byte, asan bytes.Buffer, crashN int) {
-    out := path.Join(n.loc, fmt.Sprintf("crash%d", crashN))
-    //Write input
-    input := bytes.NewBuffer(seed)
-    err := os.WriteFile(fmt.Sprintf("%s.in", out), input.Bytes(), 0660)
-    if err != nil {
-        log.Fatal(err)
-    }
-    //Write ASAN data
-    report := bytes.NewBufferString("ASAN:\n\n")
-    report.Write(asan.Bytes())
-    err = os.WriteFile(fmt.Sprintf("%s.report", out), report.Bytes(), 0660)
-    if err != nil {
-        log.Fatal(err)
-    }
-}
-
-func (n *HopperNode) getCov(cov_cmd *exec.Cmd, sancov_file string) ([]string, bool){
-    var out bytes.Buffer
-    cov_cmd.Stdout = &out
-    if err := cov_cmd.Run(); err != nil {
-        return nil, false
-    }
-    go os.Remove(sancov_file)
-    // Coverage tree parsing
-    covered := gjson.Get(out.String(), "covered-points").Array()
-    cov_s := []string{}
-    for _, v := range covered {
-        edge := gjson.Get(out.String(), fmt.Sprintf("point-symbol-info.*.*.%v", v.Value()))
-        cov_s = append(cov_s, fmt.Sprintf("%s", edge.Value()))
-    }
-    return cov_s, true
-}
-
 func (n *HopperNode) fuzz(t c.FTask) {
     //Run seed
     var fuzzCommand []string
@@ -103,7 +55,7 @@ func (n *HopperNode) fuzz(t c.FTask) {
     // Should seed be passed in as a file or raw
     if n.raw {
         seed = string(t.Seed)
-    } else {
+    } else if !n.stdin {
         f, err := os.CreateTemp("", "hopper.*.in")
         defer os.Remove(f.Name())
         if err != nil {
@@ -117,6 +69,7 @@ func (n *HopperNode) fuzz(t c.FTask) {
         }
         seed = f.Name()
     }
+    // Stdin or file
     if n.stdin {
         fuzzCommand = strings.Split(n.args, " ")
     } else {
@@ -160,39 +113,34 @@ func (n *HopperNode) fuzz(t c.FTask) {
     )
     //Crash Detected
     if err != nil {
-        update.Crash = parseAsan(errOut.String())
+        update.Crash = ParseAsan(errOut.String())
         n.crashN++
     }
-    cov_cmd := exec.Command(SANCOV,
-        "--symbolize",
-        sancov_file,
-        n.target,
-    )
     //Generate Coverage data
-    cov_s, ok := n.getCov(cov_cmd, sancov_file)
+    cov_s, ok := GetCoverage(sancov_file)
     update.Ok = ok
-    go func(update c.UpdateFTask, errOut bytes.Buffer, N int){
+    go func(update c.UpdateFTask, errOut bytes.Buffer, N uint64){
         if update.Ok {
-            update.CovEdges = len(cov_s)
-            update.CovHash = c.Hash([]byte(strings.Join(cov_s, "-")))
+            update.CovEdges = uint64(len(cov_s))
+            update.CovHash = c.BloomHash([]byte(strings.Join(cov_s, "-")))
         }
         log := n.updateFTask(update)
         if log {
-            go n.persistCrash(t.Seed, errOut, n.crashN)
+            PersistCrash(t.Seed, errOut, n.crashN, n.outDir)
         }
     }(update, errOut, n.crashN)
 }
 
-func Node(id int, target string, args string, raw bool, env string, stdin bool, master string) {
+func Node(id uint64, target string, args string, raw bool, env string, stdin bool, master string) {
     out_dir := os.Getenv("HOPPER_OUT")
-    var loc string
+    var location string
     if out_dir != "" {
-        loc = path.Join(out_dir, fmt.Sprintf("Node%d", id))
+        location = path.Join(out_dir, fmt.Sprintf("Node%d", id))
     } else {
-        loc = fmt.Sprintf("Node%d", id)
+        location = fmt.Sprintf("Node%d", id)
     }
     n := HopperNode{
-        loc:     loc,
+        outDir:  location,
         id:      id,
         target:  target,
         args:    args,
@@ -217,7 +165,7 @@ func Node(id int, target string, args string, raw bool, env string, stdin bool, 
     n.conn = c
     defer n.conn.Close()
     // Create node out dir
-    if err := os.MkdirAll(n.loc, 0750); err != nil && !os.IsExist(err) {
+    if err := os.MkdirAll(n.outDir, 0750); err != nil && !os.IsExist(err) {
         log.Fatal(err)
     }
     //Infinite loop, request Task -> do Task
@@ -233,7 +181,7 @@ func Node(id int, target string, args string, raw bool, env string, stdin bool, 
 
 func main() {
     // HOPPER_OUT="."
-    id      := flag.Int("I", 0, "Node ID, usually just a unique int")
+    id      := flag.Uint64("I", 0, "Node ID, usually just a unique int")
     target  := flag.String("T", "", "instrumented target binary")
     args    := flag.String("args", "", "args to use against target, ex: --depth=1 @@")
     raw     := flag.Bool("raw", false, "should input be fed as pure string (default: input as a file arg)")
@@ -274,4 +222,3 @@ func (n *HopperNode) call(rpcname string, args interface{}, reply interface{}) b
 
     return true           
 }
-    

--- a/node/node.go
+++ b/node/node.go
@@ -173,6 +173,7 @@ func Node(id uint64, target string, args string, raw bool, env string, stdin boo
     for {
         ftask, ok := n.getFTask()
         if !ok || ftask.Die {
+            log.Printf("Killing Node")
             return
         }
         n.fuzz(ftask)

--- a/node/utils.go
+++ b/node/utils.go
@@ -10,6 +10,9 @@ import (
     "os/exec"
 )
 
+//Deb sid: "sancov-15"
+const SANCOV = "sancov"
+
 func ParseAsan(asan string) string{
     asan_lines := strings.Split(asan, "\n")
     for _, line := range asan_lines {
@@ -37,9 +40,6 @@ func PersistCrash(seed []byte, asan bytes.Buffer, crashN uint64, outDir string) 
         log.Fatal(err)
     }
 }
-
-//Deb sid: "sancov-15"
-const SANCOV = "sancov"
 
 func GetCoverage(sancov_file string) ([]string, bool){
     cov_cmd := exec.Command(SANCOV,

--- a/node/utils.go
+++ b/node/utils.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+    "os"
+    "fmt"
+    "log"
+    "strings"
+    "path"
+    "bytes"
+    "os/exec"
+)
+
+func ParseAsan(asan string) string{
+    asan_lines := strings.Split(asan, "\n")
+    for _, line := range asan_lines {
+        sline := strings.Split(line, " ")
+        if sline[0] == "SUMMARY:"{
+            return sline[2]
+        }
+    }
+    return ""
+}
+
+func PersistCrash(seed []byte, asan bytes.Buffer, crashN uint64, outDir string) {
+    out := path.Join(outDir, fmt.Sprintf("crash%d", crashN))
+    //Write input
+    input := bytes.NewBuffer(seed)
+    err := os.WriteFile(fmt.Sprintf("%s.in", out), input.Bytes(), 0660)
+    if err != nil {
+        log.Fatal(err)
+    }
+    //Write ASAN data
+    report := bytes.NewBufferString("ASAN:\n\n")
+    report.Write(asan.Bytes())
+    err = os.WriteFile(fmt.Sprintf("%s.report", out), report.Bytes(), 0660)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+
+//Deb sid: "sancov-15"
+const SANCOV = "sancov"
+
+func GetCoverage(sancov_file string) ([]string, bool){
+    cov_cmd := exec.Command(SANCOV,
+        "--print",
+        sancov_file,
+    )
+    var out bytes.Buffer
+    cov_cmd.Stdout = &out
+    if err := cov_cmd.Run(); err != nil {
+        return nil, false
+    }
+    go os.Remove(sancov_file)
+    // Coverage tree parsing
+    covered := strings.Split(strings.Trim(out.String(), "\n"), "\n")
+    for i, v := range covered {
+        covered[i] = v[2:]
+    }
+    return covered, true
+}
+

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	h "github.com/Cybergenik/hopper/master"
@@ -100,31 +99,31 @@ func (m Model) View() string {
         `,
 		labelstyle.Width(70).Render(HOPPER),
 		datastyle.Width(60).Render(hline),
-		datastyle.Width(30).Render("Master running on port: "+strconv.Itoa(m.stats.Port)),
+		datastyle.Width(30).Render(fmt.Sprintf("Master running on port: %d", m.stats.Port)),
 		// Fields
 		labelstyle.Width(6).Render("Havoc:"),
 		labelstyle.Width(15).Render("Its/s:"),
 		labelstyle.Width(6).Render("Edges:"),
 		// Data
-		datastyle.Width(6).Render(strconv.Itoa(m.stats.Havoc)),
-		datastyle.Width(15).Render(strconv.Itoa(m.stats.Its-m.oldStats.Its)+"/s"),
-		datastyle.Width(6).Render(strconv.Itoa(m.stats.MaxSeed.CovEdges)),
+		datastyle.Width(6).Render(fmt.Sprintf("%d", m.stats.Havoc)),
+		datastyle.Width(15).Render(fmt.Sprintf("%d/s", m.stats.Its-m.oldStats.Its)),
+		datastyle.Width(6).Render(fmt.Sprintf("%d", m.stats.MaxCov)),
 		// Fields
 		labelstyle.Width(6).Render("Seeds:"),
 		labelstyle.Width(15).Render("Crashes:"),
 		labelstyle.Width(15).Render("Fuzz Instances:"),
 		// Data
-		datastyle.Width(6).Render(strconv.Itoa(m.stats.SeedsN)),
-		datastyle.Width(15).Render(strconv.Itoa(m.stats.CrashN)),
-		datastyle.Width(15).Render(strconv.Itoa(m.stats.Its)),
+		datastyle.Width(6).Render(fmt.Sprintf("%d", m.stats.SeedsN)),
+		datastyle.Width(15).Render(fmt.Sprintf("%d", m.stats.CrashN)),
+		datastyle.Width(15).Render(fmt.Sprintf("%d", m.stats.Its)),
 		// Fields
 		labelstyle.Width(6).Render("Nodes:"),
 		labelstyle.Width(15).Render("Unique Crashes:"),
 		labelstyle.Width(13).Render("Unique Paths:"),
 		// Data
-		datastyle.Width(6).Render(strconv.Itoa(m.stats.Nodes)),
-		datastyle.Width(15).Render(strconv.Itoa(m.stats.UniqueCrashes)),
-		datastyle.Width(13).Render(strconv.Itoa(m.stats.UniquePaths)),
+		datastyle.Width(6).Render(fmt.Sprintf("%d", m.stats.Nodes)),
+		datastyle.Width(15).Render(fmt.Sprintf("%d", m.stats.UniqueCrashes)),
+		datastyle.Width(13).Render(fmt.Sprintf("%d", m.stats.UniquePaths)),
 		// Quit
 		substyle.Width(30).Render("Press Space to Generate Report"),
 		substyle.Width(30).Render("Press Esc or Ctrl+C to quit"),


### PR DESCRIPTION
Implemented BloomFilter:

Used exisitng impl for BF: https://github.com/bits-and-blooms/bloom:
- Modified to extract correct murmur hash interface
- Worker nodes need to compute the BloomFilter Hash, however the BloomFilter itself exists on the master

Murmur hash implementation is also used from the above rep:
- Originally modified off of Sébastien Paolacci's implementation. The Licenses for both of these files 

The original licenses for both of these kept in their own respective files.

Usage:

2 BloomFilters are used in Hopper:
- Seed BloomFilter is used to deduplicate seeds
- Coverage BloomFilter is used to deduplicate/rank lower energy to seeds with same/similar coverage.

*Other quality of life changes also made to using more explicit typing instead of just ints for everything*
